### PR TITLE
Gas costbasis simplified

### DIFF
--- a/perfi/costbasis.py
+++ b/perfi/costbasis.py
@@ -1192,7 +1192,7 @@ class CostbasisGenerator:
         # LATER: we should be considering TxLogical fees, approvals, etc...
         # Basis should equal the price * amount + value_of_fees
         value_of_fee = 0
-        if self.fee and self.fee.amount > 0:
+        if self.fee and self.fee.amount > 0 and self.fee.price_usd:
             value_of_fee = self.fee.amount * self.fee.price_usd
         basis_usd = decimal_mul(price, t.amount) + value_of_fee
 
@@ -1290,7 +1290,12 @@ class CostbasisGenerator:
                     # Attrs for new Costbasis disposal row
                     # If this is not a disposal for a fee (because all fees are their own disposal events), and if this transaction has a fee...
                     fee_value_usd = 0
-                    if not t.isfee and self.fee and self.fee.amount > 0:
+                    if (
+                        not t.isfee
+                        and self.fee
+                        and self.fee.amount > 0
+                        and self.fee.price_usd
+                    ):
                         # Subtract total fee value from the total_usd of this disposal
                         fee_value_usd = self.fee.amount * self.fee.price_usd
                     total_usd = decimal_mul(amount, sale_price) - fee_value_usd

--- a/perfi/models.py
+++ b/perfi/models.py
@@ -367,9 +367,13 @@ class TxLogical(BaseModel):
         if len(self.outs) > 0:
             chain = self.outs[0].chain
             hash = self.outs[0].hash
-        if len(self.ins) > 0:
+        elif len(self.ins) > 0:
             chain = self.ins[0].chain
             hash = self.ins[0].hash
+        elif self.fee:
+            chain = self.fee.chain
+            hash = self.fee.hash
+
         return " | ".join(
             [
                 datestamp,

--- a/perfi/transaction/chain_to_ledger.py
+++ b/perfi/transaction/chain_to_ledger.py
@@ -391,8 +391,15 @@ class LedgerTx:
 
             if self.amount > 0:
                 # Use DeBank's USD price
-                self.price_usd = debank_tx_data["usd_gas_fee"]
+                self.price_usd = Decimal(debank_tx_data["usd_gas_fee"]) / Decimal(
+                    self.amount
+                )
                 self.price_source = "debank"
+
+                if self.price_usd is None:
+                    raise Exception(
+                        f"Unexpected none value for price_usd from debank\n {self}"
+                    )
             else:
                 self.price_usd = Decimal(0)
                 self.price_source = "zero_fee_value"

--- a/perfi/transaction/ledger_to_logical.py
+++ b/perfi/transaction/ledger_to_logical.py
@@ -118,7 +118,7 @@ class TransactionLogicalGrouper:
         self.assign_tx_perfi_type_for_logicals(address)
 
         # We are now done grouping. Printing here for dubugging pursposes.
-        self.print_groupings(address)
+        # self.print_groupings(address)
 
     def assign_tx_perfi_type_for_logicals(self, address):
         """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -93,8 +93,8 @@ class TxFactory:
         from_address = kwargs.get("from_address") or self.address
         to_address_name = kwargs.get("to_address_name")
         from_address_name = kwargs.get("from_address_name") or None
-        fee = kwargs.get("fee") or 0.001
-        fee = f"{fee} XYZ"  # Stored as a string in our DB
+        fee = kwargs.get("fee") or 0.00
+        fee_usd = kwargs.get("fee_usd") or 0.00
         gas_price = kwargs.get("gas_price") or 1
         gas_used = kwargs.get("gas_used") or 1
         hash = kwargs.get("hash")
@@ -169,7 +169,13 @@ class TxFactory:
                     debank_name = "send"
 
             return dict(
-                tx=dict(name=debank_name),
+                tx=dict(
+                    name=debank_name,
+                    from_addr=from_address,
+                    to_addr=to_address,
+                    eth_gas_fee=fee,
+                    usd_gas_fee=fee_usd,
+                ),
                 receives=receives,
                 sends=sends,
             )

--- a/tests/integration/test_chain_generate_ledgertxs.py
+++ b/tests/integration/test_chain_generate_ledgertxs.py
@@ -54,7 +54,7 @@ def test_swap_one_for_one_generates_3_ledger_txs(monkeypatch, test_db):
     ethereum.tx(
         ins=["1 DAI"],
         outs=[".1 ETH"],
-        fee=0.00123,
+        fee=0.00,
         timestamp=1,
         to_address="__MAKER_DAO",
     )


### PR DESCRIPTION
Factor gas costs and exchange fees into cost basis and disposals.

- Use DeBank's gas_price_usd for valuing total price of gas paid in USD 
- Add the fee paid to the costbasis price for assets forming new costbasis lots
- Subtract fee paid from disposal total_usd
