### PR TITLE
Costbasis locking wip

### DIFF
--- a/bin/cli.py
+++ b/bin/cli.py
@@ -139,6 +139,13 @@ def entity_add_address(entity_name: str, label: str, chain: Chain, address: str)
         print(f"Created address {address}")
 
 
+@entity_app.command("lock_costbasis_lots")
+def entity_lock_costbasis_lots(entity_name: str, year: int):
+    event = event_store.create_costbasis_lots_locked(entity_name, year, source="manual")
+    event_store.apply_event(event)
+    print(f"Locked costbasis lots for entity {entity_name} and year {year}")
+
+
 # Setting
 # ---------------------------------------------
 setting_app = typer.Typer()

--- a/bin/close_year.py
+++ b/bin/close_year.py
@@ -1,0 +1,47 @@
+import argparse
+import logging
+
+from devtools import debug
+
+from perfi import costbasis
+from perfi.constants.paths import LOG_DIR
+import sys
+
+if sys.stdout.isatty():
+    console = logging.StreamHandler()
+    console.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(asctime)s : %(levelname)-8s : %(message)s")
+    costbasis.logger.addHandler(console)
+
+args = None
+
+
+def close_year(entity_name: str, year: int = None, output_path: str = None):
+    entity = entity_name
+    logging.basicConfig(
+        level=logging.WARN,
+        format="%(asctime)s : %(levelname)-8s : %(message)s",
+        filename=f"{LOG_DIR}/costbasis.close_year.{entity}-{year}.log",
+    )
+
+    f = costbasis.CostbasisYearCloser(entity, year, output_path)
+    f.lock_costbasis_lots()
+    f.export_closing_values()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("entity", help="name of entity")
+    parser.add_argument(
+        "--year", help="Locks and exports the cost basis lots for a specific year"
+    )
+    parser.add_argument(
+        "--output", help="Path for closed cost basis values export file"
+    )
+    global args
+    args = parser.parse_args()
+    close_year(args.entity, args.year, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/perfi.schema.sql
+++ b/perfi.schema.sql
@@ -182,6 +182,7 @@ CREATE TABLE IF NOT EXISTS "costbasis_lot" (
 	"flags"	text,
 	"receipt"	INTEGER,
 	"price_source" TEXT,
+	"locked_for_year" INTEGER,
 	PRIMARY KEY("tx_ledger_id")
 );
 CREATE TABLE IF NOT EXISTS "asset_price" (

--- a/perfi/api.py
+++ b/perfi/api.py
@@ -59,6 +59,7 @@ from bin.cli import (
     ledger_remove_flag_logical,
     ledger_move_tx_ledger,
     CommandNotPermittedException,
+    entity_lock_costbasis_lots,
 )
 from bin.import_from_exchange import do_import
 from bin.map_assets import generate_constants
@@ -537,8 +538,7 @@ def generate_tax_report(
 # ============================================================
 @app.post("/lock_costbasis_lots/{entity}/{year}")
 def lock_costbasis_lots(entity: str, year: int):
-    costbasis_closer = costbasis.CostbasisYearCloser(entity, year, None)
-    costbasis_closer.lock_costbasis_lots()
+    entity_lock_costbasis_lots(entity, year)
     return {"ok": year}
 
 

--- a/perfi/costbasis.py
+++ b/perfi/costbasis.py
@@ -2421,13 +2421,20 @@ class CostbasisYearCloser:
         )
 
     def lock_costbasis_lots(self):
+        # We want to lock all costbasis lots that were either 1) created this year or 2) drawn down from in the target year
         start_timestamp = int(datetime(self.year, 1, 1).timestamp())
         end_timestamp = int(datetime(self.year + 1, 1, 1).timestamp())
-
-        # We want to lock all costbasis lots that were involved in any disposals for the year
         sql = """UPDATE costbasis_lot
                  SET locked_for_year = :year
                  WHERE tx_ledger_id in (
+                    SELECT tx_ledger_id
+                    FROM tx_ledger
+                    WHERE timestamp >= :start
+                    AND timestamp < :end
+                    AND entity = :entity
+                 )
+                 OR
+                 tx_ledger_id in (
                     SELECT tx_ledger_id
                     FROM costbasis_disposal
                     WHERE timestamp >= :start
@@ -2441,7 +2448,6 @@ class CostbasisYearCloser:
             end=end_timestamp,
             entity=self.entity,
         )
-        db.con.set_trace_callback(print)
         db.execute(sql, params)
 
     def export_closing_values(self):
@@ -2461,3 +2467,5 @@ class CostbasisYearCloser:
             writer.writeheader()
             for r in results:
                 writer.writerow(dict(**r))
+
+        print(f"Exported closing values to {self.closing_values_file_path}")

--- a/perfi/costbasis.py
+++ b/perfi/costbasis.py
@@ -89,6 +89,8 @@ def get_active_branch_name():
     for line in content:
         if line[0:4] == "ref:":
             return line.partition("refs/heads/")[2]
+        else:
+            return line[:10]
 
 
 def regenerate_costbasis_lots(entity, args=None, quiet=False):

--- a/perfi/models.py
+++ b/perfi/models.py
@@ -730,6 +730,7 @@ class CostbasisLot(BaseModel):
     receipt: int
     price_source: str
     chain: str
+    locked_for_year: Optional[int]
 
 
 class CostbasisDisposal(BaseModel):
@@ -1058,3 +1059,27 @@ class TxLedgerStore(BaseStore[TxLedger]):
         ]
         self.db.execute(sql, params)
         return tx
+
+
+class CostbasisLotStore:
+    def __init__(self, db):
+        self.db = db
+
+    def find(self, **kwargs) -> List[CostbasisLot]:
+        where = " AND ".join([f"{arg} = ?" for arg in kwargs])
+        sql = f"""SELECT *
+                  FROM costbasis_lot
+                  WHERE {where}
+               """
+        params = [kwargs[arg] for arg in kwargs]
+        rows = self.db.query(sql, params)
+
+        results = []
+        for r in rows:
+            r_dict = dict(**r)
+            r_dict["history"] = jsonpickle.decode(r["history"])
+            r_dict.pop("flags")
+            flags = load_flags(CostbasisLot.__name__, r["tx_ledger_id"])
+            lot = CostbasisLot(flags=flags, **r_dict)
+            results.append(lot)
+        return results

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,11 +1,15 @@
+import datetime
+import time
 import uuid
 from decimal import Decimal
 from typing import List
 
+import jsonpickle
 import pytest
 from _pytest.python_api import approx
 from starlette.testclient import TestClient
 from perfi.api import app, TxLogicalOut
+from perfi.costbasis import regenerate_costbasis_lots
 from perfi.events import EventStore
 from perfi.models import (
     AddressStore,
@@ -42,6 +46,7 @@ def common_setup(monkeysession, test_db, setup_asset_and_price_ids):
     monkeysession.setattr("perfi.api.DB", test_db_returner)
     monkeysession.setattr("perfi.models.db", test_db)
     monkeysession.setattr("bin.cli.db", test_db)
+    monkeysession.setattr("bin.cli.costbasis_lot_store.db", test_db)
     monkeysession.setattr("perfi.transaction.ledger_to_logical.db", test_db)
     monkeysession.setattr("perfi.costbasis.db", test_db)
     monkeysession.setattr("bin.cli.event_store", event_store)
@@ -446,3 +451,60 @@ def test_reparent_tx_ledger(test_db):
     tx_ledger_store = TxLedgerStore(test_db)
     updated_ledger = tx_ledger_store.find_by_primary_key(tx_ledger.id)[0]
     assert updated_ledger.tx_logical_id == tx_logical_2.id
+
+
+def test_lock_costbasis_lot_then_try_to_edit_tx_ledger_price_should_give_error(test_db):
+    entity_store = EntityStore(test_db)
+    entity = entity_store.create(name="Foo")
+
+    address_store = AddressStore(test_db)
+    address = address_store.create("foo", Chain.ethereum, "0x123", entity_id=entity.id)
+
+    tx_logical_store = TxLogicalStore(test_db)
+    timestamp_now = int(time.time())
+    tx_logical = make_tx_logical(
+        entity_name=entity.name,
+        address=address.address,
+        tx_ledgers=[
+            make_tx_ledger(
+                address.address,
+                "OUT",
+                "swap",
+                timestamp=timestamp_now,
+                symbol="AVAX",
+                amount=10,
+                price_usd=Decimal(100),
+            ),
+            make_tx_ledger(
+                address.address,
+                "IN",
+                "swap",
+                timestamp=timestamp_now,
+                symbol="ETH",
+                amount=1,
+                price_usd=Decimal(1000),
+            ),
+        ],
+        tx_logical_type=TX_LOGICAL_TYPE.swap,
+        timestamp=timestamp_now,
+    )
+    tx_logical = tx_logical_store._create_for_tests(tx_logical)
+
+    regenerate_costbasis_lots(entity.name, args=None, quiet=True)
+
+    # Lock the costbasis lots
+    year = datetime.datetime.fromtimestamp(timestamp_now).year
+    client.post(f"/lock_costbasis_lots/{entity.name}/{year}")
+
+    # Now try to edit the price of the tx_ledger that associated with the locked costbasis_lot
+    tx_ledger = tx_logical.ins[0]
+    updated_price = Decimal(99.87)
+    response = client.put(f"/tx_ledgers/{tx_ledger.id}/tx_ledger_price/{updated_price}")
+
+    # We should see an error in the API response
+    assert response.status_code == 200
+    assert response.json()["error"]
+
+    # Let's also make sure the price didn't get updated on the ledger
+    tx_ledger_store = TxLedgerStore(test_db)
+    assert tx_ledger_store.find(id=tx_ledger.id)[0].price_usd == Decimal(1000)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -10,7 +10,7 @@ from _pytest.python_api import approx
 from starlette.testclient import TestClient
 from perfi.api import app, TxLogicalOut
 from perfi.costbasis import regenerate_costbasis_lots
-from perfi.events import EventStore
+from perfi.events import EventStore, EVENT_ACTION
 from perfi.models import (
     AddressStore,
     Chain,
@@ -453,58 +453,118 @@ def test_reparent_tx_ledger(test_db):
     assert updated_ledger.tx_logical_id == tx_logical_2.id
 
 
-def test_lock_costbasis_lot_then_try_to_edit_tx_ledger_price_should_give_error(test_db):
-    entity_store = EntityStore(test_db)
-    entity = entity_store.create(name="Foo")
+class TestCostbasisLocking:
+    def test_lock_costbasis_lot_then_try_to_edit_tx_ledger_price_should_give_error(
+        self, test_db
+    ):
+        entity_store = EntityStore(test_db)
+        entity = entity_store.create(name="Foo")
 
-    address_store = AddressStore(test_db)
-    address = address_store.create("foo", Chain.ethereum, "0x123", entity_id=entity.id)
+        address_store = AddressStore(test_db)
+        address = address_store.create(
+            "foo", Chain.ethereum, "0x123", entity_id=entity.id
+        )
 
-    tx_logical_store = TxLogicalStore(test_db)
-    timestamp_now = int(time.time())
-    tx_logical = make_tx_logical(
-        entity_name=entity.name,
-        address=address.address,
-        tx_ledgers=[
-            make_tx_ledger(
-                address.address,
-                "OUT",
-                "swap",
-                timestamp=timestamp_now,
-                symbol="AVAX",
-                amount=10,
-                price_usd=Decimal(100),
-            ),
-            make_tx_ledger(
-                address.address,
-                "IN",
-                "swap",
-                timestamp=timestamp_now,
-                symbol="ETH",
-                amount=1,
-                price_usd=Decimal(1000),
-            ),
-        ],
-        tx_logical_type=TX_LOGICAL_TYPE.swap,
-        timestamp=timestamp_now,
-    )
-    tx_logical = tx_logical_store._create_for_tests(tx_logical)
+        tx_logical_store = TxLogicalStore(test_db)
+        timestamp_now = int(time.time())
+        tx_logical = make_tx_logical(
+            entity_name=entity.name,
+            address=address.address,
+            tx_ledgers=[
+                make_tx_ledger(
+                    address.address,
+                    "OUT",
+                    "swap",
+                    timestamp=timestamp_now,
+                    symbol="AVAX",
+                    amount=10,
+                    price_usd=Decimal(100),
+                ),
+                make_tx_ledger(
+                    address.address,
+                    "IN",
+                    "swap",
+                    timestamp=timestamp_now,
+                    symbol="ETH",
+                    amount=1,
+                    price_usd=Decimal(1000),
+                ),
+            ],
+            tx_logical_type=TX_LOGICAL_TYPE.swap,
+            timestamp=timestamp_now,
+        )
+        tx_logical = tx_logical_store._create_for_tests(tx_logical)
 
-    regenerate_costbasis_lots(entity.name, args=None, quiet=True)
+        regenerate_costbasis_lots(entity.name, args=None, quiet=True)
 
-    # Lock the costbasis lots
-    year = datetime.datetime.fromtimestamp(timestamp_now).year
-    client.post(f"/lock_costbasis_lots/{entity.name}/{year}")
+        # Lock the costbasis lots
+        year = datetime.datetime.fromtimestamp(timestamp_now).year
+        client.post(f"/lock_costbasis_lots/{entity.name}/{year}")
 
-    # Now try to edit the price of the tx_ledger that associated with the locked costbasis_lot
-    tx_ledger = tx_logical.ins[0]
-    updated_price = Decimal(99.87)
-    response = client.put(f"/tx_ledgers/{tx_ledger.id}/tx_ledger_price/{updated_price}")
+        # Now try to edit the price of the tx_ledger that associated with the locked costbasis_lot
+        tx_ledger = tx_logical.ins[0]
+        updated_price = Decimal(99.87)
+        response = client.put(
+            f"/tx_ledgers/{tx_ledger.id}/tx_ledger_price/{updated_price}"
+        )
 
-    # We should see an error in the API response
-    assert response.status_code == 200
-    assert response.json()["error"]
+        # We should see an error in the API response
+        assert response.status_code == 200
+        assert response.json()["error"]
 
-    # Let's also make sure the price didn't get updated on the ledger
-    tx_ledger_store = TxLedgerStore(test_db)
-    assert tx_ledger_store.find(id=tx_ledger.id)[0].price_usd == Decimal(1000)
+        # Let's also make sure the price didn't get updated on the ledger
+        tx_ledger_store = TxLedgerStore(test_db)
+        assert tx_ledger_store.find(id=tx_ledger.id)[0].price_usd == Decimal(1000)
+
+    def test_lock_costbasis_creates_and_applies_a_COSTBASIS_LOCKED_event(self, test_db):
+        entity_store = EntityStore(test_db)
+        entity = entity_store.create(name="Foo")
+
+        address_store = AddressStore(test_db)
+        address = address_store.create(
+            "foo", Chain.ethereum, "0x123", entity_id=entity.id
+        )
+
+        event_store = EventStore(test_db, TxLogical, TxLedger)
+
+        tx_logical_store = TxLogicalStore(test_db)
+        timestamp_now = int(time.time())
+        tx_logical = make_tx_logical(
+            entity_name=entity.name,
+            address=address.address,
+            tx_ledgers=[
+                make_tx_ledger(
+                    address.address,
+                    "OUT",
+                    "swap",
+                    timestamp=timestamp_now,
+                    symbol="AVAX",
+                    amount=10,
+                    price_usd=Decimal(100),
+                ),
+                make_tx_ledger(
+                    address.address,
+                    "IN",
+                    "swap",
+                    timestamp=timestamp_now,
+                    symbol="ETH",
+                    amount=1,
+                    price_usd=Decimal(1000),
+                ),
+            ],
+            tx_logical_type=TX_LOGICAL_TYPE.swap,
+            timestamp=timestamp_now,
+        )
+        tx_logical = tx_logical_store._create_for_tests(tx_logical)
+
+        regenerate_costbasis_lots(entity.name, args=None, quiet=True)
+
+        # Lock the costbasis lots
+        year = datetime.datetime.fromtimestamp(timestamp_now).year
+        client.post(f"/lock_costbasis_lots/{entity.name}/{year}")
+
+        # We should have a COSTBASIS_LOTS_LOCKED event for this entity/year
+        events = event_store.find_events(EVENT_ACTION.costbasis_lots_locked)
+        assert len(events) == 1
+        assert events[0].data["year"] == year
+        assert events[0].data["entity_name"] == entity.name


### PR DESCRIPTION
Adds a CLI command and API endpoint to lock all costbasis lots for an entity that were created/drawndown-from in a target year.

• locking is accomplished via creating and applying a COSTBASIS_LOTS_LOCKED event

• costbasis lot is considered locked based on a non-null (integer year) value on a costbasis_locked_for_year column (added to costbasis_lot schema)

• after a costbasis lot is locked, you can't use the CLI/API to set a new price for a tx_ledger that is associated with a locked costbasis lot

Also adds a CLI command to lock and export the costbasis lots for a given entity/year, producing a CSV file dump of the locked lots